### PR TITLE
feat(object-code): compatible with versions below typescript 5.2.0 (`WeakKey`)

### DIFF
--- a/packages/object-code/src/hash.ts
+++ b/packages/object-code/src/hash.ts
@@ -24,7 +24,7 @@ import { sortNumbers } from './util';
  * @returns The signed integer result from the provided value
  * @see https://tinylibs.js.org/packages/object-code/
  */
-export function hash(val: unknown, seen?: WeakSet<WeakKey>): number {
+export function hash(val: unknown, seen?: WeakSet<object>): number {
   let h = 5381;
 
   // Objects should be recursively hashed
@@ -43,7 +43,7 @@ export function hash(val: unknown, seen?: WeakSet<WeakKey>): number {
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const value = val[key as keyof typeof val] as WeakKey;
+      const value = val[key as keyof typeof val] as object;
 
       h = (h * 33) ^ hash(key, seen);
 


### PR DESCRIPTION
For more compatibility, hope to remove the use of `WeakKey`

`WeakKey` is referenced after typescript 5.2.0

https://github.com/microsoft/TypeScript/pull/54195